### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "X11::Xlib::Raw",
+    "license" : "Artistic-2.0",
     "version" : "*",
     "description" : "Xlib binding using NativeCall",
     "depends" : [ "NativeHelpers::Blob" ],

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "X11::Xlib::Raw",
-    "license" : "Artistic-2.0",
+    "license" : "Artistic-2.0 AND X11",
     "version" : "*",
     "description" : "Xlib binding using NativeCall",
     "depends" : [ "NativeHelpers::Blob" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license